### PR TITLE
Replace X-StorageApi-Token with X-KBC-ManageApiToken header

### DIFF
--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -6,9 +6,9 @@ namespace Keboola\EncryptionApiClient;
 
 class Migrations extends Common
 {
-    public function __construct(string $sapiToken, array $config)
+    public function __construct(string $manageApiToken, array $config)
     {
-        parent::__construct(['X-StorageApi-Token' => $sapiToken], $config);
+        parent::__construct(['X-KBC-ManageApiToken' => $manageApiToken], $config);
     }
 
     public function migrateConfiguration(

--- a/tests/MigrationsTest.php
+++ b/tests/MigrationsTest.php
@@ -31,7 +31,11 @@ class MigrationsTest extends TestCase
             ],
         );
 
+        // Add the history middleware to the handler stack.
+        $container = [];
+        $history = Middleware::history($container);
         $stack = HandlerStack::create($mock);
+        $stack->push($history);
 
         $migrations = new Migrations(
             'some-token',
@@ -58,6 +62,15 @@ class MigrationsTest extends TestCase
             ],
             $result,
         );
+
+        /** @var Request $request */
+        $request = $container[0]['request'];
+        self::assertSame(
+            'https://encryption.keboola.com/migrate-configuration',
+            (string) $request->getUri(),
+        );
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('some-token', $request->getHeader('X-KBC-ManageApiToken')[0]);
     }
 
     public function testRetryCurlExceptionFail(): void


### PR DESCRIPTION
`X-KBC-ManageApiToken` [is required](https://github.com/keboola/encryption-api/blob/92fcddeef1361bc05945477e893cb903fe16c9bb/tests/Controller/MigrateConfiguration/MigrateConfigurationActionTest.php#L29) at `POST /migrate-configuration` in service `encryption-api`

https://keboola.atlassian.net/browse/PST-1686
