### PR TITLE
PAT-1866 Support service-account auth for Migrations with a null manage token

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ $result = $migrations->migrateConfiguration(
 );
 ```
 
+The manage token is optional. When it is omitted (or `null`), `Migrations` authenticates with the
+projected Connection service-account token instead — useful for in-cluster service-to-service calls:
+
+```php
+$migrations = new Migrations('https://encryption.keboola.com'); // service-account auth
+```
+
 On a failed request both clients throw `Keboola\EncryptionApiClient\Exception\ClientException`
 (a subclass of `Keboola\ApiClientBase\Exception\ClientException`). The exception exposes
 `getStatusCode()` and `getResponseBody()` for the failing response, when available.

--- a/src/Migrations.php
+++ b/src/Migrations.php
@@ -9,6 +9,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use Keboola\ApiClientBase\ApiClient;
 use Keboola\ApiClientBase\ApiClientOptions;
+use Keboola\ApiClientBase\Auth\KeboolaServiceAccountAuthenticator;
 use Keboola\ApiClientBase\Auth\ManageApiTokenAuthenticator;
 use Keboola\ApiClientBase\Json;
 use Keboola\EncryptionApiClient\Exception\ClientException;
@@ -23,12 +24,13 @@ class Migrations
 
     /**
      * @param non-empty-string $baseUrl
-     * @param non-empty-string $manageApiToken
+     * @param non-empty-string|null $manageToken When null, authenticates via the projected Connection
+     *     service-account token ({@see KeboolaServiceAccountAuthenticator}) instead of a Manage API token.
      * @param int<0, max> $backoffMaxTries
      */
     public function __construct(
         string $baseUrl,
-        string $manageApiToken,
+        ?string $manageToken = null,
         ?LoggerInterface $logger = null,
         int $backoffMaxTries = ApiClientOptions::DEFAULT_BACKOFF_MAX_TRIES,
         int $connectTimeout = ApiClientOptions::DEFAULT_CONNECT_TIMEOUT,
@@ -38,9 +40,13 @@ class Migrations
     ) {
         Assert::stringNotEmpty($baseUrl, 'Base URL must be a non-empty string');
 
+        $authenticator = $manageToken !== null
+            ? new ManageApiTokenAuthenticator($manageToken)
+            : new KeboolaServiceAccountAuthenticator();
+
         $this->apiClient = new ApiClient(
             $baseUrl,
-            new ManageApiTokenAuthenticator($manageApiToken),
+            $authenticator,
             new ApiClientOptions(
                 userAgent: $userAgent,
                 backoffMaxTries: $backoffMaxTries,

--- a/tests/MigrationsTest.php
+++ b/tests/MigrationsTest.php
@@ -7,6 +7,7 @@ namespace Keboola\EncryptionApiClient\Tests;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
 use Keboola\ApiClientBase\Json;
 use Keboola\EncryptionApiClient\Exception\ClientException;
 use Keboola\EncryptionApiClient\Migrations;
@@ -215,6 +216,46 @@ class MigrationsTest extends TestCase
             self::assertSame('Encryption API error: Configuration not found', $e->getMessage());
             self::assertSame(400, $e->getStatusCode());
             self::assertSame(Json::encodeArray(['message' => 'Configuration not found']), $e->getResponseBody());
+        }
+    }
+
+    public function testEmptyManageTokenThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Manage API token must not be empty');
+
+        new Migrations(self::BASE_URL, ''); // @phpstan-ignore-line
+    }
+
+    public function testNullManageTokenUsesServiceAccountAuth(): void
+    {
+        // With a null manage token the client authenticates via the projected Connection
+        // service-account token. That token file is absent in the test environment, so the
+        // service-account authenticator fails before any request is sent — which proves it
+        // (not manage-token auth) was selected and that the request never left the client.
+        $requestHandler = self::createRequestHandler($requestsHistory, [
+            new Response(200, ['Content-Type' => 'application/json'], Json::encodeArray(self::SUCCESS_BODY)),
+        ]);
+
+        $migrations = new Migrations(
+            self::BASE_URL,
+            null,
+            backoffMaxTries: 0,
+            requestHandler: $requestHandler(...),
+        );
+
+        try {
+            $migrations->migrateConfiguration(
+                'source-token',
+                'some-stack',
+                'destination-token',
+                'keboola.some-component',
+                '1234',
+                '102',
+            );
+            self::fail('Expected ClientException to be thrown');
+        } catch (ClientException $e) {
+            self::assertCount(0, $requestsHistory);
         }
     }
 }


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1866/unified-api-client-base

> [!NOTE]
> Doplneni podpory pro Connection ServiceAccount token (nahrada aplikacnich tokenu). Pro `sandboxes-service` to neni potreba, ale tak at uz mame toho API clienta vyresenyho komplet.

Adds service-account authentication to the `Migrations` client. The manage token is now optional (`?string $manageToken = null`, renamed from `$manageApiToken`): a non-empty token authenticates with `X-KBC-ManageApiToken` as before, while a null token (the new default) authenticates via the projected Connection service-account token (`KeboolaServiceAccountAuthenticator` → `X-Kubernetes-Authorization`), as the `git-service` client already does. This lets in-cluster callers reach the Encryption API without holding a Manage API token.

An empty string is still rejected by the authenticator's non-empty assertion, so the only way to opt into service-account auth is to pass `null` (or omit the argument).

## Plans for customer communication
None.

## Impact analysis
Breaking only for callers passing the manage token by name (`manageApiToken:` → `manageToken:`); positional `new Migrations($baseUrl, $token)` callers are unaffected. The parameter now defaults to `null`, so `new Migrations($baseUrl)` newly resolves to service-account auth instead of being a missing-argument error. Released as part of the same new major version.

## Change type
New feature

## Justification
Allow `Migrations` to authenticate with the Connection service-account token when no Manage API token is available (PAT-1866).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.